### PR TITLE
Add course categories in the Footer

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,7 +5,8 @@ import { categories, courses } from "./store"
 
 class App extends Component {
   state = {
-    courses
+    courses,
+    category: 'engineering'
   };
 
   getCoursesByCategory = () => {
@@ -20,15 +21,23 @@ class App extends Component {
     }, {}));
   }
 
+  handleCategorySelected = (category) => {
+    this.setState({
+      category
+    })
+
+  }
+
   render() {
     console.log(this.getCoursesByCategory());
     const courses = this.getCoursesByCategory();
+    const { category } = this.state;
     return (
       <Fragment>
         <Header />
         <h4>Hi from React</h4>
-        <Courses courses={courses}/>
-        <Footer categories={categories}/>
+        <Courses courses={courses} category={category}/>
+        <Footer category={category} categories={categories} onSelect={this.handleCategorySelected}/>
       </Fragment>
     );
   }

--- a/src/Components/Courses/index.js
+++ b/src/Components/Courses/index.js
@@ -20,23 +20,26 @@ const styles = {
 };
 
 // export default a function that is going to recieve props
-export default ({ courses }) => (
+export default ({ courses, category }) => (
   <Grid container>
     <Grid item sm={3}>
       <Paper style={styles.Paper}>
-        {courses.map(([category, courses]) => (
-          <Fragment>
-            <Typography variant="h6" style={{ textTransform: "capitalize" }}>
-              {category}
-            </Typography>
-            <List component="ul">
-              {courses.map(({ title }) => (
-                <ListItem button>
-                  <ListItemText primary={title} />
-                </ListItem>
-              ))}
-            </List>
-          </Fragment>
+        {courses.map(([group, courses]) => (
+          !category || category === group
+          ? <Fragment>
+          <Typography variant="h6" style={{ textTransform: "capitalize" }}>
+            {group}
+          </Typography>
+          <List component="ul">
+            {courses.map(({ title }) => (
+              <ListItem button>
+                <ListItemText primary={title} />
+              </ListItem>
+            ))}
+          </List>
+        </Fragment>
+          : null
+          
         ))}
       </Paper>
     </Grid>

--- a/src/Components/Layouts/Footer.js
+++ b/src/Components/Layouts/Footer.js
@@ -2,13 +2,27 @@ import React from "react";
 import { Paper, Tabs, Tab } from "@material-ui/core";
 
 // export default a function that is going to recieve props
-export default ({ categories }) => (
+export default ({ categories, category, onSelect }) => {
+  const index = category
+    ? categories.findIndex(group => group === category) + 1
+    : 0
+
+  const onIndexSelect = (e, index) => {
+    onSelect(index === 0 ? '' : categories[index - 1])
+  }
+  return (
   <Paper style={{ margin: 10 }}>
-    <Tabs value={0} indicatorColor="primary" textColor="primary" centered>
+    <Tabs
+    value={index}
+    onChange={onIndexSelect}
+    indicatorColor="primary"
+    textColor="primary"
+    centered
+    >
     <Tab label="All"/>
       {categories.map(category => (
         <Tab label={category} />
       ))}
     </Tabs>
   </Paper>
-);
+)};


### PR DESCRIPTION
#### What does this PR do?
- add course categories to the footer for easy selection

#### Description of Task to be completed?
- cluster the courses using the course categories
- add the categories in the footer of the app

#### How should this be manually tested?
- pull the branch and start the server by running `yarn start`
- click on any of the categories to filter through the courses

#### Any background context you want to provide?

#### What are the relevant pivotal tracker stories?

#### Screenshots (if appropriate)
<img width="1440" alt="Screen Shot 2019-07-03 at 16 17 43" src="https://user-images.githubusercontent.com/31615608/60594677-27da5080-9dae-11e9-82ce-5555fb39bde4.png">


#### Questions:
